### PR TITLE
Limit dependency versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ packages = find:
 python_requires = >=3.7
 
 install_requires =
-    gqlmod>=0.8.0
+    gqlmod~=0.8.0
 
 setup_requires =
     wheel


### PR DESCRIPTION
With breaking changes coming to gqlmod, limit versions.